### PR TITLE
korean_lunar_calendar 0.3.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: eb2c485124a061016926bdea6d89efdf9b9fdbf16db55895b6cf1e5bec17b857
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "korean_lunar_calendar" %}
-{% set version = "0.2.1" %}
-
+{% set version = "0.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,18 +7,18 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 12ce54b1392ed45a82dc6cea85ee5f7e33630556e82488f57e37a22482c8275d
+  sha256: eb2c485124a061016926bdea6d89efdf9b9fdbf16db55895b6cf1e5bec17b857
 
 build:
-  skip: True   # [py<36]
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
     - python
+    - wheel
+    - setuptools
   run:
     - python
 
@@ -27,7 +26,6 @@ test:
   imports:
     - korean_lunar_calendar
   requires:
-    - python <3.10
     - pip
   commands:
     - pip check
@@ -36,7 +34,10 @@ about:
   home: https://github.com/usingsky/korean_lunar_calendar_py
   summary: Korean Lunar Calendar
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  description: |
+    Korean calendar and Chinese calendar is same lunar calendar but have different date.
   dev_url: https://github.com/usingsky/korean_lunar_calendar_py
   doc_url: https://github.com/usingsky/korean_lunar_calendar_py
 


### PR DESCRIPTION
korean_lunar_calendar 0.3.1 

**Destination channel:** Defaults

### Links

- [PKG-9404]
- dev_url:        https://github.com/usingsky/korean_lunar_calendar_py/tree/master
- conda_forge:    https://github.com/conda-forge/korean_lunar_calendar-feedstock
- pypi:           https://pypi.org/project/korean_lunar_calendar/0.3.1
- pypi inspector: https://inspector.pypi.io/project/korean_lunar_calendar/0.3.1

### Explanation of changes:

- new version number


[PKG-9404]: https://anaconda.atlassian.net/browse/PKG-9404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ