### PR TITLE
korean_lunar_calendar 0.4.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,18 @@
 {% set name = "korean_lunar_calendar" %}
-{% set version = "0.3.1" %}
+{% set version = "0.4.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: eb2c485124a061016926bdea6d89efdf9b9fdbf16db55895b6cf1e5bec17b857
+  sha256: be56f27bc0594fdbbdf7bbe00f504a9f929a31e311bd7d9bb93561b645afade7
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<36]
 
 requirements:
   host:


### PR DESCRIPTION
korean_lunar_calendar 0.4.0 

**Destination channel:** Defaults

### Links

- [PKG-15739]
- dev_url:        https://github.com/usingsky/korean_lunar_calendar_py/tree/v0.4.0
- conda_forge:    https://github.com/conda-forge/korean_lunar_calendar-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- new version number


[PKG-15739]: https://anaconda.atlassian.net/browse/PKG-15739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ